### PR TITLE
Add About Us and Terms & Conditions pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,8 @@ import StockFeedScreen from './components/screens/StockFeedScreen';
 import LocationsScreen from './components/screens/LocationsScreen';
 import SettingsScreen from './components/screens/SettingsScreen';
 import ReportViewerScreen from './components/screens/ReportViewerScreen';
+import AboutUsScreen from './components/screens/AboutUsScreen';
+import TermsScreen from './components/screens/TermsScreen';
 import ErrorBoundary from './components/utility/ErrorBoundary';
 import { useDeviceDetection, useLocalStorage } from './hooks';
 
@@ -157,6 +159,8 @@ function App() {
             {activeScreen === 'more' && <MoreScreen onNavigate={handleNavigate} isMobile={isMobile} onLogout={handleLogout} user={user} />}
             {activeScreen === 'locations' && <LocationsScreen isMobile={isMobile} user={user} />}
             {activeScreen === 'settings' && <SettingsScreen isMobile={isMobile} onNavigate={handleNavigate} user={user} />}
+            {activeScreen === 'about-us' && <AboutUsScreen onNavigate={handleNavigate} />}
+            {activeScreen === 'terms' && <TermsScreen onNavigate={handleNavigate} />}
           </ErrorBoundary>
         </div>
         

--- a/src/App.js
+++ b/src/App.js
@@ -159,8 +159,8 @@ function App() {
             {activeScreen === 'more' && <MoreScreen onNavigate={handleNavigate} isMobile={isMobile} onLogout={handleLogout} user={user} />}
             {activeScreen === 'locations' && <LocationsScreen isMobile={isMobile} user={user} />}
             {activeScreen === 'settings' && <SettingsScreen isMobile={isMobile} onNavigate={handleNavigate} user={user} />}
-            {activeScreen === 'about-us' && <AboutUsScreen onNavigate={handleNavigate} />}
-            {activeScreen === 'terms' && <TermsScreen onNavigate={handleNavigate} />}
+            {activeScreen === 'about-us' && <AboutUsScreen onNavigate={handleNavigate} isMobile={isMobile} />}
+            {activeScreen === 'terms' && <TermsScreen onNavigate={handleNavigate} isMobile={isMobile} />}
           </ErrorBoundary>
         </div>
         

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -5,7 +5,8 @@ import {
   MapPin,
   Settings,
   LogOut,
-  Calculator
+  Calculator,
+  HelpCircle
 } from 'lucide-react';
 import beetGuruSquareLogo from '../../BeetGuruSq.png';
 
@@ -83,6 +84,18 @@ const Sidebar = ({ activeScreen, handleNavigate, onLogout, user }) => {
               label="Settings" 
               isActive={activeScreen === 'settings'} 
               onClick={() => handleNavigate('settings')}
+            />
+            <SidebarItem 
+              icon={<HelpCircle size={20} />} 
+              label="About Us" 
+              isActive={activeScreen === 'about-us'} 
+              onClick={() => handleNavigate('about-us')}
+            />
+            <SidebarItem 
+              icon={<FileText size={20} />} 
+              label="Terms & Conditions" 
+              isActive={activeScreen === 'terms'} 
+              onClick={() => handleNavigate('terms')}
             />
             <SidebarItem 
               icon={<LogOut size={20} />} 

--- a/src/components/screens/AboutUsScreen.js
+++ b/src/components/screens/AboutUsScreen.js
@@ -7,20 +7,22 @@ import { FormButton } from '../ui/form';
  * @param {Object} props - Component props
  * @returns {JSX.Element} Rendered component
  */
-const AboutUsScreen = ({ onNavigate }) => {
+const AboutUsScreen = ({ onNavigate, isMobile = false }) => {
   return (
     <div className="space-y-6">
-      {/* Header with back button */}
-      <div className="flex items-center mb-4">
-        <FormButton
-          variant="outline"
-          icon={<ArrowLeft size={16} />}
-          onClick={() => onNavigate('more')}
-          size="sm"
-        >
-          Back
-        </FormButton>
-      </div>
+      {/* Header with back button - only shown on mobile */}
+      {isMobile && (
+        <div className="flex items-center mb-4">
+          <FormButton
+            variant="outline"
+            icon={<ArrowLeft size={16} />}
+            onClick={() => onNavigate('more')}
+            size="sm"
+          >
+            Back
+          </FormButton>
+        </div>
+      )}
       
       {/* Main content */}
       <div className="bg-white rounded-xl shadow p-6">

--- a/src/components/screens/AboutUsScreen.js
+++ b/src/components/screens/AboutUsScreen.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { FormButton } from '../ui/form';
+
+/**
+ * Screen for displaying the About Us information
+ * @param {Object} props - Component props
+ * @returns {JSX.Element} Rendered component
+ */
+const AboutUsScreen = ({ onNavigate }) => {
+  return (
+    <div className="space-y-6">
+      {/* Header with back button */}
+      <div className="flex items-center mb-4">
+        <FormButton
+          variant="outline"
+          icon={<ArrowLeft size={16} />}
+          onClick={() => onNavigate('more')}
+          size="sm"
+        >
+          Back
+        </FormButton>
+      </div>
+      
+      {/* Main content */}
+      <div className="bg-white rounded-xl shadow p-6">
+        <h1 className="text-2xl font-bold text-gray-800 mb-4">About Agricom</h1>
+        
+        <div className="mb-6">
+          <img 
+            src="https://www.agricom.co.nz/themes/custom/agricom/logo.svg" 
+            alt="Agricom Logo" 
+            className="h-16 mb-4"
+          />
+          <p className="text-gray-600 mb-4">
+            Agricom has been a leader in the New Zealand pastoral industry for over 30 years, 
+            bringing farmers the best forage cultivars from around the world.
+          </p>
+        </div>
+        
+        <h2 className="text-xl font-semibold text-gray-800 mb-3">Our Mission</h2>
+        <p className="text-gray-600 mb-6">
+          To provide New Zealand farmers with superior forage solutions, backed by proven research and 
+          dedicated technical support to help maximize their on-farm productivity and profitability.
+        </p>
+        
+        <h2 className="text-xl font-semibold text-gray-800 mb-3">Beet Guru App</h2>
+        <p className="text-gray-600 mb-4">
+          The Beet Guru app was developed to help farmers manage their fodder beet crops more efficiently 
+          through easy-to-use digital tools for measuring, monitoring, and planning.
+        </p>
+        <p className="text-gray-600 mb-4">
+          With Beet Guru, farmers can accurately assess crop yield, determine dry matter content, 
+          and plan feeding schedules to optimize animal nutrition and farm productivity.
+        </p>
+        
+        <h2 className="text-xl font-semibold text-gray-800 mb-3">Our Expertise</h2>
+        <p className="text-gray-600 mb-4">
+          With decades of experience in fodder beet research and development, our team provides 
+          farmers with the knowledge and tools they need to succeed with this valuable crop.
+        </p>
+        <p className="text-gray-600 mb-4">
+          We work closely with farmers across New Zealand to understand their unique challenges 
+          and develop solutions that work in real-world farm environments.
+        </p>
+        
+        <h2 className="text-xl font-semibold text-gray-800 mb-3">Contact Us</h2>
+        <div className="text-gray-600">
+          <p className="mb-2">Agricom</p>
+          <p className="mb-2">PO Box 3761</p>
+          <p className="mb-2">Christchurch 8140</p>
+          <p className="mb-2">New Zealand</p>
+          <p className="mb-2">Phone: +64 3 372 0800</p>
+          <p>Email: info@agricom.co.nz</p>
+        </div>
+      </div>
+      
+      {/* App version info */}
+      <div className="bg-white rounded-xl shadow p-4 text-center">
+        <p className="text-gray-500 text-sm">Beet Guru v1.0.0</p>
+        <p className="text-xs text-gray-400 mt-1">© 2025 Agricom New Zealand</p>
+      </div>
+    </div>
+  );
+};
+
+export default AboutUsScreen;

--- a/src/components/screens/MoreScreen.js
+++ b/src/components/screens/MoreScreen.js
@@ -1,4 +1,4 @@
-import { MapPin, Settings, LogOut, ChevronRight, Calculator } from 'lucide-react';
+import { MapPin, Settings, LogOut, ChevronRight, Calculator, HelpCircle, FileText } from 'lucide-react';
 
 const MoreScreen = ({ onNavigate, onLogout, user }) => {
   return (
@@ -34,6 +34,16 @@ const MoreScreen = ({ onNavigate, onLogout, user }) => {
             icon={<Settings size={20} className="text-gray-600" />}
             label="Settings"
             onClick={() => onNavigate('settings')}
+          />
+          <MenuItem 
+            icon={<HelpCircle size={20} className="text-blue-600" />}
+            label="About Us"
+            onClick={() => onNavigate('about-us')}
+          />
+          <MenuItem 
+            icon={<FileText size={20} className="text-blue-600" />}
+            label="Terms & Conditions"
+            onClick={() => onNavigate('terms')}
           />
           <MenuItem 
             icon={<LogOut size={20} className="text-red-500" />}

--- a/src/components/screens/TermsScreen.js
+++ b/src/components/screens/TermsScreen.js
@@ -7,20 +7,22 @@ import { FormButton } from '../ui/form';
  * @param {Object} props - Component props
  * @returns {JSX.Element} Rendered component
  */
-const TermsScreen = ({ onNavigate }) => {
+const TermsScreen = ({ onNavigate, isMobile = false }) => {
   return (
     <div className="space-y-6">
-      {/* Header with back button */}
-      <div className="flex items-center mb-4">
-        <FormButton
-          variant="outline"
-          icon={<ArrowLeft size={16} />}
-          onClick={() => onNavigate('more')}
-          size="sm"
-        >
-          Back
-        </FormButton>
-      </div>
+      {/* Header with back button - only shown on mobile */}
+      {isMobile && (
+        <div className="flex items-center mb-4">
+          <FormButton
+            variant="outline"
+            icon={<ArrowLeft size={16} />}
+            onClick={() => onNavigate('more')}
+            size="sm"
+          >
+            Back
+          </FormButton>
+        </div>
+      )}
       
       {/* Main content */}
       <div className="bg-white rounded-xl shadow p-6">

--- a/src/components/screens/TermsScreen.js
+++ b/src/components/screens/TermsScreen.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { FormButton } from '../ui/form';
+
+/**
+ * Screen for displaying the Terms & Conditions
+ * @param {Object} props - Component props
+ * @returns {JSX.Element} Rendered component
+ */
+const TermsScreen = ({ onNavigate }) => {
+  return (
+    <div className="space-y-6">
+      {/* Header with back button */}
+      <div className="flex items-center mb-4">
+        <FormButton
+          variant="outline"
+          icon={<ArrowLeft size={16} />}
+          onClick={() => onNavigate('more')}
+          size="sm"
+        >
+          Back
+        </FormButton>
+      </div>
+      
+      {/* Main content */}
+      <div className="bg-white rounded-xl shadow p-6">
+        <h1 className="text-2xl font-bold text-gray-800 mb-4">Terms & Conditions</h1>
+        
+        <div className="text-gray-600 space-y-6">
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">1. Acceptance of Terms</h2>
+            <p>
+              By accessing and using the Beet Guru application ("App"), you acknowledge that you have read, 
+              understood, and agree to be bound by these Terms & Conditions. If you do not agree with any part of 
+              these terms, you must not use the App.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">2. App License</h2>
+            <p>
+              Subject to these Terms & Conditions, we grant you a limited, non-exclusive, non-transferable license 
+              to use the App for your personal or business farming activities. This license does not allow you to 
+              modify, distribute, or create derivative works based on the App.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">3. User Accounts</h2>
+            <p>
+              To use certain features of the App, you may need to create a user account. You are responsible for 
+              maintaining the confidentiality of your account information and for all activities that occur under your 
+              account. You agree to notify us immediately of any unauthorized use of your account.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">4. Data and Privacy</h2>
+            <p>
+              We respect your privacy and are committed to protecting your personal information. Our collection 
+              and use of your data is governed by our Privacy Policy, which is incorporated into these Terms & Conditions 
+              by reference.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">5. App Content and Calculations</h2>
+            <p>
+              The App provides tools for estimating crop yields, dry matter content, and feeding schedules. These 
+              calculations are based on algorithms and models that, while designed to be accurate, may not account for all 
+              variables affecting actual crop performance. You should use the App's outputs as guidance only and combine 
+              them with your professional judgment and experience.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">6. Disclaimer of Warranties</h2>
+            <p>
+              The App is provided "as is" and "as available" without warranties of any kind, either express or implied. 
+              We do not guarantee that the App will be error-free, uninterrupted, or that it will meet your specific 
+              requirements.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">7. Limitation of Liability</h2>
+            <p>
+              To the maximum extent permitted by law, we shall not be liable for any indirect, incidental, special, 
+              consequential, or punitive damages, including lost profits, arising out of or relating to your use or 
+              inability to use the App.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">8. Changes to Terms</h2>
+            <p>
+              We reserve the right to modify these Terms & Conditions at any time. We will provide notice of significant 
+              changes through the App or by other means. Your continued use of the App after such modifications constitutes 
+              your acceptance of the updated terms.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">9. Governing Law</h2>
+            <p>
+              These Terms & Conditions shall be governed by and construed in accordance with the laws of New Zealand, 
+              without regard to its conflict of law provisions.
+            </p>
+          </section>
+          
+          <section>
+            <h2 className="text-xl font-semibold text-gray-800 mb-3">10. Contact Information</h2>
+            <p>
+              If you have any questions about these Terms & Conditions, please contact us at legal@beetguru.co.nz.
+            </p>
+          </section>
+          
+          <section className="pt-4 border-t border-gray-200">
+            <p className="text-sm text-gray-500">
+              Last updated: May 14, 2025
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TermsScreen;


### PR DESCRIPTION
## Changes

This PR adds two new pages to the More menu and desktop sidebar: "About Us" and "Terms & Conditions".

### New Components
1. **AboutUsScreen**: 
   - Displays information about Agricom, the company behind Beet Guru
   - Includes the company's mission, expertise, and contact information
   - Features a back button only in mobile view

2. **TermsScreen**: 
   - Contains a comprehensive set of terms and conditions for the app
   - Organized into 10 sections covering usage, licensing, liability, etc.
   - Features a back button only in mobile view

### UI Changes
- Added two new menu items to the MoreScreen (mobile):
  - "About Us" with a help circle icon (blue)
  - "Terms & Conditions" with a file text icon (blue)
  - Both appear below Settings and above Logout

- Added the same menu items to the desktop Sidebar:
  - "About Us" with a help circle icon (white)
  - "Terms & Conditions" with a file text icon (white)
  - Both appear below Settings and above Logout
  - Maintain consistent styling with other sidebar items

- Updated App.js to handle routing to these new screens

### Implementation Details
- Created responsive layouts for both new screens
- Used consistent styling with the rest of the application
- Implemented proper navigation between screens
- Added placeholder content that can be customized by the client
- Ensured the same navigation options are available in both mobile and desktop views
- Back buttons only appear on mobile, not in desktop view (as desktop has the sidebar navigation)
- Passes the isMobile prop from App.js to control display of back buttons

This enhancement provides users with important legal and company information, which is a standard requirement for mobile applications.