### PR TITLE
Create reusable PageHeader component

### DIFF
--- a/src/components/screens/AssessmentsScreen.js
+++ b/src/components/screens/AssessmentsScreen.js
@@ -4,6 +4,7 @@ import LocationCard from '../ui/LocationCard';
 import api from '../../services/api';
 import { useApi } from '../../hooks';
 import { FormButton } from '../ui/form';
+import PageHeader from '../ui/PageHeader';
 
 /**
  * Screen for displaying and managing assessments
@@ -50,25 +51,19 @@ const AssessmentsScreen = ({
   return (
     <div className="space-y-6">
       {/* Header Section */}
-      <div className="bg-white rounded-xl shadow p-6">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-800 mb-1">
-              Assessments
-            </h1>
-            <p className="text-gray-600">
-              Manage crop assessments for your locations
-            </p>
-          </div>
-          <FormButton 
-            variant="primary" 
+      <PageHeader
+        title="Assessments"
+        subtitle="Manage crop assessments for your locations"
+        actions={(
+          <FormButton
+            variant="primary"
             icon={<PlusCircle size={16} />}
             onClick={handleNewAssessment}
           >
             {isMobile ? 'New' : 'New Assessment'}
           </FormButton>
-        </div>
-      </div>
+        )}
+      />
       
       {/* Loading State */}
       {loading && (

--- a/src/components/screens/HomeScreen.js
+++ b/src/components/screens/HomeScreen.js
@@ -5,6 +5,7 @@ import WeatherWidget from '../ui/WeatherWidget';
 import CultivarInfoWidget from '../ui/CultivarInfoWidget';
 import SeasonalTimeline from '../ui/SeasonalTimeline';
 import { FormButton } from '../ui/form';
+import PageHeader from '../ui/PageHeader';
 
 /**
  * Home screen component with dashboard widgets
@@ -30,31 +31,33 @@ const HomeScreen = ({ onNavigate, isMobile = false, user = { name: 'John Doe' } 
     logger.info('Learn more about harvesting');
   };
 
+  const headerSubtitle = (
+    <>
+      <p className="mb-2">
+        Beet Guru simplifies estimating beet dry matter yield by calculating an accurate average from fresh weight samples. It provides a clear, reliable yield range, making your farm planning more effective and data-driven.
+      </p>
+      <p>
+        Easy-to-use and intuitive, Beet Guru securely stores your grower and paddock details directly within each assessment. At the end of the process, you'll receive a comprehensive and easy-to-read report via email, streamlining your record-keeping and decision-making.
+      </p>
+    </>
+  );
+
   return (
     <div className="space-y-6">
       {/* Header Card */}
-      <div className="bg-white rounded-xl shadow p-6">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-800 mb-1">
-              Welcome, {user.name}
-            </h1>
-            <p className="text-gray-600 mb-2">
-              Beet Guru simplifies estimating beet dry matter yield by calculating an accurate average from fresh weight samples. It provides a clear, reliable yield range, making your farm planning more effective and data-driven.
-            </p>
-            <p className="text-gray-600">
-              Easy-to-use and intuitive, Beet Guru securely stores your grower and paddock details directly within each assessment. At the end of the process, you'll receive a comprehensive and easy-to-read report via email, streamlining your record-keeping and decision-making.
-            </p>
-          </div>
-          <FormButton 
-            variant="primary" 
+      <PageHeader
+        title={`Welcome, ${user.name}`}
+        subtitle={headerSubtitle}
+        actions={(
+          <FormButton
+            variant="primary"
             icon={<PlusCircle size={16} />}
             onClick={handleNewAssessment}
           >
             {isMobile ? 'New' : 'New Assessment'}
           </FormButton>
-        </div>
-      </div>
+        )}
+      />
 
       {/* Mobile Layout (stacked) */}
       <div className="grid grid-cols-1 md:hidden gap-6">

--- a/src/components/screens/ReportsScreen.js
+++ b/src/components/screens/ReportsScreen.js
@@ -5,6 +5,7 @@ import AssessmentTable from '../ui/AssessmentTable';
 import api from '../../services/api';
 import { useApi } from '../../hooks';
 import { FormButton } from '../ui/form';
+import PageHeader from '../ui/PageHeader';
 
 /**
  * Screen for displaying and managing reports
@@ -168,25 +169,19 @@ const ReportsScreen = ({ isMobile, onViewReport = () => {} }) => {
   return (
     <div className="space-y-6">
       {/* Header Section */}
-      <div className="bg-white rounded-xl shadow p-6">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-800 mb-1">
-              Reports
-            </h1>
-            <p className="text-gray-600">
-              View and share your assessment reports
-            </p>
-          </div>
-          <FormButton 
-            variant="primary" 
+      <PageHeader
+        title="Reports"
+        subtitle="View and share your assessment reports"
+        actions={(
+          <FormButton
+            variant="primary"
             icon={<Download size={16} />}
             onClick={handleExport}
           >
             {isMobile ? 'Export' : 'Export Reports'}
           </FormButton>
-        </div>
-      </div>
+        )}
+      />
       
       {/* Mobile Filter Toggle */}
       {isMobile && (

--- a/src/components/ui/PageHeader.js
+++ b/src/components/ui/PageHeader.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+/**
+ * Reusable page header component
+ * @param {Object} props - Component props
+ * @param {string|React.ReactNode} props.title - Page title
+ * @param {string|React.ReactNode} [props.subtitle] - Optional subtitle content
+ * @param {React.ReactNode} [props.actions] - Optional actions area (buttons, links)
+ * @returns {JSX.Element} Rendered component
+ */
+const PageHeader = ({ title, subtitle, actions = null }) => (
+  <div className="bg-white rounded-xl shadow p-6">
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-800 mb-1">{title}</h1>
+        {subtitle && (
+          typeof subtitle === 'string' ? (
+            <p className="text-gray-600">{subtitle}</p>
+          ) : (
+            <div className="text-gray-600">{subtitle}</div>
+          )
+        )}
+      </div>
+      {actions && <div className="flex gap-2">{actions}</div>}
+    </div>
+  </div>
+);
+
+export default PageHeader;


### PR DESCRIPTION
## Summary
- add `PageHeader` UI component for consistent page titles
- use `PageHeader` on Home, Assessments and Reports screens

## Testing
- `npm test -- -w 1`