### PR TITLE
Fix step scroll behavior

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -202,7 +202,7 @@ function App() {
           </ErrorBoundary>
         )}
         
-        <div className="flex-1 overflow-y-auto p-4 pb-16 md:pb-4">
+        <div id="main-content" className="flex-1 overflow-y-auto p-4 pb-16 md:pb-4">
           <ErrorBoundary>
             {activeScreen === 'home' && <HomeScreen onNavigate={handleNavigate} isMobile={isMobile} user={user} />}
             {activeScreen === 'assessments' && (

--- a/src/components/screens/NewAssessmentScreen.js
+++ b/src/components/screens/NewAssessmentScreen.js
@@ -69,21 +69,28 @@ const NewAssessmentScreen = ({
       }));
     }
   }, [prefillLocation, draftAssessment]);
-  
+
+  const scrollToTop = () => {
+    const mainContent = document.getElementById('main-content');
+    if (mainContent) {
+      mainContent.scrollTo({ top: 0 });
+      return;
+    }
+    window.scrollTo({ top: 0 });
+  };
+
   // Navigation between steps
   const nextStep = () => {
     if (currentStep < 4) {
       setCurrentStep(currentStep + 1);
-      // Scroll to top when changing steps
-      window.scrollTo(0, 0);
+      scrollToTop();
     }
   };
-  
+
   const prevStep = () => {
     if (currentStep > 1) {
       setCurrentStep(currentStep - 1);
-      // Scroll to top when changing steps
-      window.scrollTo(0, 0);
+      scrollToTop();
     }
   };
   


### PR DESCRIPTION
## Summary
- add `main-content` id to the scrolling container
- scroll the container to the top whenever changing steps in the New Assessment wizard

## Testing
- `npm test -- --watchAll=false`