### PR TITLE
Add skeleton loaders for report screens

### DIFF
--- a/src/components/screens/ReportViewerScreen.js
+++ b/src/components/screens/ReportViewerScreen.js
@@ -13,6 +13,7 @@ import { useApi } from '../../hooks';
 import enhancedApi from '../../services/enhancedApi';
 import { FormButton } from '../ui/form';
 import PageContainer from '../layout/PageContainer';
+import ReportViewerSkeleton from '../ui/ReportViewerSkeleton';
 
 /**
  * Detailed report viewer component that displays a single report
@@ -94,11 +95,7 @@ const ReportViewerScreen = ({
 
   // Loading state
   if (loadingReport || loadingAssessment) {
-    return (
-      <div className="bg-white rounded-xl shadow p-6 text-center">
-        <p className="text-gray-500">Loading report...</p>
-      </div>
-    );
+    return <ReportViewerSkeleton />;
   }
 
   // Error state

--- a/src/components/screens/ReportsScreen.js
+++ b/src/components/screens/ReportsScreen.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { ChevronDown, Filter, X, FileText, Calendar, Leaf, ArrowDownUp, Download } from 'lucide-react';
 import { logger } from '../../utils/logger';
 import DataTable from '../ui/DataTable';
+import ReportsTableSkeleton from '../ui/ReportsTableSkeleton';
 import api from '../../services/api';
 import { useApi } from '../../hooks';
 import { FormButton } from '../ui/form';
@@ -351,9 +352,7 @@ const ReportsScreen = ({ isMobile, onViewReport = () => {} }) => {
       
       {/* Loading State */}
       {(loading || loadingAssessments) && (
-        <div className="bg-white rounded-xl shadow p-6 text-center">
-          <p className="text-gray-500">Loading reports...</p>
-        </div>
+        <ReportsTableSkeleton rows={3} />
       )}
       
       {/* Error State */}

--- a/src/components/ui/ReportViewerSkeleton.js
+++ b/src/components/ui/ReportViewerSkeleton.js
@@ -1,0 +1,71 @@
+import PageContainer from '../layout/PageContainer';
+import Skeleton from './Skeleton';
+
+const ReportViewerSkeleton = () => (
+  <PageContainer>
+    <div className="flex justify-between items-center mb-4">
+      <Skeleton className="h-10 w-32" />
+      <Skeleton className="h-10 w-32" />
+    </div>
+    <div className="bg-white rounded-xl shadow overflow-hidden">
+      <div className="p-6 border-b border-gray-100 min-h-[120.667px]">
+        <Skeleton className="h-8 w-1/2 mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <Skeleton key={i} className="h-4 w-full" />
+          ))}
+        </div>
+      </div>
+      <div className="p-6 border-b border-gray-100 space-y-2 min-h-[140.667px]">
+        <Skeleton className="h-6 w-48 mb-4" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-0 min-h-[436.667px]">
+        <div className="p-6 border-b md:border-r border-gray-100 space-y-2">
+          <Skeleton className="h-6 w-48 mb-4" />
+          {[...Array(6)].map((_, i) => (
+            <Skeleton key={i} className="h-4 w-3/4" />
+          ))}
+        </div>
+        <div className="p-6 border-b border-gray-100 space-y-2">
+          <Skeleton className="h-6 w-48 mb-4" />
+          {[...Array(6)].map((_, i) => (
+            <Skeleton key={i} className="h-4 w-3/4" />
+          ))}
+        </div>
+      </div>
+      <div className="p-6 bg-green-50 border-b border-gray-100 min-h-[644.667px]">
+        <Skeleton className="h-6 w-48 mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {[...Array(2)].map((_, i) => (
+            <div key={i} className="bg-white rounded-lg p-6 shadow-sm space-y-2">
+              <Skeleton className="h-6 w-32 mb-4" />
+              <Skeleton className="h-8 w-24 mb-2" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          ))}
+        </div>
+        <div className="mt-6">
+          <Skeleton className="h-6 w-48 mb-4" />
+          <div className="bg-white rounded-lg p-6 shadow-sm h-64" />
+        </div>
+      </div>
+      <div className="p-6 border-b border-gray-100">
+        <Skeleton className="h-6 w-48 mb-4" />
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full mb-2" />
+        ))}
+      </div>
+      <div className="p-6">
+        <Skeleton className="h-6 w-48 mb-4" />
+        {[...Array(3)].map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full mb-2" />
+        ))}
+      </div>
+    </div>
+  </PageContainer>
+);
+
+export default ReportViewerSkeleton;

--- a/src/components/ui/ReportsTableSkeleton.js
+++ b/src/components/ui/ReportsTableSkeleton.js
@@ -1,0 +1,47 @@
+import Skeleton from './Skeleton';
+
+const ReportsTableSkeleton = ({ rows = 3 }) => {
+  const headers = [
+    'Date',
+    'Report Title',
+    'Location',
+    'Cultivar/Crop Type',
+    'Season',
+    'Actions'
+  ];
+
+  return (
+    <div className="bg-white rounded-xl shadow overflow-hidden">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            {headers.map((header) => (
+              <th
+                key={header}
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {Array.from({ length: rows }).map((_, rowIndex) => (
+            <tr
+              key={rowIndex}
+              className={`${rowIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'} min-h-[53px]`}
+            >
+              {headers.map((_, cellIndex) => (
+                <td key={cellIndex} className="px-6 py-4 whitespace-nowrap">
+                  <Skeleton className="h-4 w-full" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ReportsTableSkeleton;


### PR DESCRIPTION
## Summary
- add table skeleton component for ReportsScreen
- add skeleton placeholders for ReportViewerScreen
- show table skeletons while reports load
- show report viewer skeleton while single report loads
- fix skeleton heights on report preview screen for better visual match

## Testing
- `npm test -- -w=0`
