### PR TITLE
Refactor demo form helpers

### DIFF
--- a/src/components/screens/EmailScreen.js
+++ b/src/components/screens/EmailScreen.js
@@ -6,6 +6,7 @@ import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import api from '../../services/api';
 import PageContainer from '../layout/PageContainer';
+import { getDemoEmail } from '../../utils/demoData';
 
 /**
  * Initial Email Screen for Magic Link authentication
@@ -45,9 +46,7 @@ const EmailScreen = ({ onEmailSubmit, onRegister, onKnownUser, onNewUser }) => {
   
   // Fill form with sample data
   const fillFormWithSampleData = () => {
-    setValues({
-      email: 'john.doe@example.com'
-    });
+    setValues(getDemoEmail());
     setFormFilled(true);
   };
   

--- a/src/components/screens/LoginScreen.js
+++ b/src/components/screens/LoginScreen.js
@@ -3,6 +3,7 @@ import { User, Lock, ArrowRight } from 'lucide-react';
 import { FormField, FormButton } from '../ui/form';
 import { useForm } from '../../hooks';
 import api from '../../services/api';
+import { getDemoCredentials } from '../../utils/demoData';
 import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import PageContainer from '../layout/PageContainer';
@@ -48,11 +49,7 @@ const LoginScreen = ({ onLogin, onRegister }) => {
   
   // Fill form with sample data
   const fillFormWithSampleData = () => {
-    setValues({
-      email: 'john.doe@example.com',
-      password: 'password',
-      rememberMe: false
-    });
+    setValues(getDemoCredentials());
     setFormFilled(true);
   };
   

--- a/src/components/screens/RegisterScreen.js
+++ b/src/components/screens/RegisterScreen.js
@@ -5,6 +5,7 @@ import { FormField, FormButton } from '../ui/form';
 import { PrimaryButton } from '../ui/buttons';
 import PageContainer from '../layout/PageContainer';
 import { cn } from '../../utils/cn';
+import { getDemoRegistrationData } from '../../utils/demoData';
 
 const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
   const [formData, setFormData] = useState({
@@ -52,15 +53,7 @@ const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
     cn(formData.userType !== type && userTypeUnselectedClass);
   
   const fillFormWithSampleData = () => {
-    setFormData({
-      name: 'Donald',
-      email: prefillEmail || 'donald@stp.co.nz',
-      password: 'password',
-      confirmPassword: 'password',
-      userType: 'farmer',
-      subscribeToNews: true,
-      agreeToTerms: true
-    });
+    setFormData(getDemoRegistrationData(prefillEmail));
     setFormFilled(true);
   };
   

--- a/src/utils/demoData.js
+++ b/src/utils/demoData.js
@@ -1,0 +1,19 @@
+export const getDemoCredentials = () => ({
+  email: 'john.doe@example.com',
+  password: 'password',
+  rememberMe: false
+});
+
+export const getDemoEmail = () => ({
+  email: 'john.doe@example.com'
+});
+
+export const getDemoRegistrationData = (prefillEmail = '') => ({
+  name: 'Donald',
+  email: prefillEmail || 'donald@stp.co.nz',
+  password: 'password',
+  confirmPassword: 'password',
+  userType: 'farmer',
+  subscribeToNews: true,
+  agreeToTerms: true
+});


### PR DESCRIPTION
## Summary
- extract demo data helpers
- use demo data helpers in login, register and email forms

## Testing
- `CI=true npm test --silent`