### PR TITLE
Refactor demo form helpers

### DIFF
--- a/src/components/screens/EmailScreen.js
+++ b/src/components/screens/EmailScreen.js
@@ -6,6 +6,7 @@ import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import api from '../../services/api';
 import PageContainer from '../layout/PageContainer';
+import { getDemoEmail, getRandomDemoPersona } from '../../utils/demoData';
 
 /**
  * Initial Email Screen for Magic Link authentication
@@ -45,9 +46,9 @@ const EmailScreen = ({ onEmailSubmit, onRegister, onKnownUser, onNewUser }) => {
   
   // Fill form with sample data
   const fillFormWithSampleData = () => {
-    setValues({
-      email: 'john.doe@example.com'
-    });
+    const persona = getRandomDemoPersona();
+    const { email } = getDemoEmail(persona);
+    setValues({ email });
     setFormFilled(true);
   };
   

--- a/src/components/screens/LoginScreen.js
+++ b/src/components/screens/LoginScreen.js
@@ -3,6 +3,7 @@ import { User, Lock, ArrowRight } from 'lucide-react';
 import { FormField, FormButton } from '../ui/form';
 import { useForm } from '../../hooks';
 import api from '../../services/api';
+import { getDemoCredentials, getRandomDemoPersona } from '../../utils/demoData';
 import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import PageContainer from '../layout/PageContainer';
@@ -14,6 +15,7 @@ import PageContainer from '../layout/PageContainer';
  */
 const LoginScreen = ({ onLogin, onRegister }) => {
   const [formFilled, setFormFilled] = useState(false);
+  const [selectedPersona, setSelectedPersona] = useState(null);
   
   // Form validation
   const validateLogin = (values) => {
@@ -48,11 +50,10 @@ const LoginScreen = ({ onLogin, onRegister }) => {
   
   // Fill form with sample data
   const fillFormWithSampleData = () => {
-    setValues({
-      email: 'john.doe@example.com',
-      password: 'password',
-      rememberMe: false
-    });
+    const persona = getRandomDemoPersona();
+    setSelectedPersona(persona);
+    const { email, password, rememberMe } = getDemoCredentials(persona);
+    setValues({ email, password, rememberMe });
     setFormFilled(true);
   };
   
@@ -65,12 +66,18 @@ const LoginScreen = ({ onLogin, onRegister }) => {
     }
     
     // Second click: Actually log in
-    onLogin({ 
-      id: '1',  // Make sure this matches the userId in the mock locations
-      email: formValues.email, 
-      name: 'John Doe', 
+    const name = selectedPersona?.name || 'John Doe';
+    const initials = name
+      .split(' ')
+      .map(n => n && n[0])
+      .join('');
+
+    onLogin({
+      id: '1', // Make sure this matches the userId in the mock locations
+      email: formValues.email,
+      name,
       role: 'Farm Manager',
-      initials: 'JD'
+      initials
     });
   }
   

--- a/src/components/screens/RegisterScreen.js
+++ b/src/components/screens/RegisterScreen.js
@@ -5,6 +5,7 @@ import { FormField, FormButton } from '../ui/form';
 import { PrimaryButton } from '../ui/buttons';
 import PageContainer from '../layout/PageContainer';
 import { cn } from '../../utils/cn';
+import { getDemoRegistrationData, getRandomDemoPersona } from '../../utils/demoData';
 
 const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
   const [formData, setFormData] = useState({
@@ -50,17 +51,10 @@ const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
     'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50';
   const getUserTypeButtonClasses = (type) =>
     cn(formData.userType !== type && userTypeUnselectedClass);
-  
+
   const fillFormWithSampleData = () => {
-    setFormData({
-      name: 'Donald',
-      email: prefillEmail || 'donald@stp.co.nz',
-      password: 'password',
-      confirmPassword: 'password',
-      userType: 'farmer',
-      subscribeToNews: true,
-      agreeToTerms: true
-    });
+    const persona = getRandomDemoPersona();
+    setFormData(getDemoRegistrationData(prefillEmail, persona));
     setFormFilled(true);
   };
   

--- a/src/utils/demoData.js
+++ b/src/utils/demoData.js
@@ -1,0 +1,42 @@
+export const demoPersonas = [
+  { name: 'John Doe', email: 'john.doe@example.com' },
+  { name: 'Maria Hernandez', email: 'maria.hernandez@example.com' },
+  { name: 'Priya Singh', email: 'priya.singh@example.com' },
+  { name: 'Wei Zhang', email: 'wei.zhang@example.com' },
+  { name: 'Aroha Patel', email: 'aroha.patel@example.com' },
+  { name: 'Ibrahim Khan', email: 'ibrahim.khan@example.com' },
+  { name: 'Lucia Rossi', email: 'lucia.rossi@example.com' },
+  { name: 'Omar Farouk', email: 'omar.farouk@example.com' },
+  { name: 'Sarah O\'Neill', email: 'sarah.oneill@example.com' },
+  { name: 'Miguel Santos', email: 'miguel.santos@example.com' },
+  { name: 'Yuki Tanaka', email: 'yuki.tanaka@example.com' },
+  { name: 'David Kim', email: 'david.kim@example.com' }
+];
+
+export const getRandomDemoPersona = () =>
+  demoPersonas[Math.floor(Math.random() * demoPersonas.length)];
+
+export const getDemoCredentials = (persona = getRandomDemoPersona()) => ({
+  email: persona.email,
+  password: 'password',
+  rememberMe: false,
+  name: persona.name
+});
+
+export const getDemoEmail = (persona = getRandomDemoPersona()) => ({
+  email: persona.email,
+  name: persona.name
+});
+
+export const getDemoRegistrationData = (
+  prefillEmail = '',
+  persona = getRandomDemoPersona()
+) => ({
+  name: persona.name,
+  email: prefillEmail || persona.email,
+  password: 'password',
+  confirmPassword: 'password',
+  userType: 'farmer',
+  subscribeToNews: true,
+  agreeToTerms: true
+});


### PR DESCRIPTION
## Summary
- extract demo data helpers
- use demo data helpers in login, register and email forms
- add random fake persona list for sample form data

## Testing
- `CI=true npm test --silent`
