### PR TITLE
Restore magic link persona flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import AboutUsScreen from './components/screens/AboutUsScreen';
 import TermsScreen from './components/screens/TermsScreen';
 import ErrorBoundary from './components/utility/ErrorBoundary';
 import { useDeviceDetection, useLocalStorage } from './hooks';
+import { getRandomDemoPersona } from './utils/demoData';
 
 function App() {
   // Use custom hooks for device detection and persisting user session
@@ -33,6 +34,7 @@ function App() {
   
   // Magic link authentication data
   const [currentEmail, setCurrentEmail] = useState('');
+  const [selectedPersona, setSelectedPersona] = useState(null);
   
   // Add state for selected location or draft assessment
   const [selectedLocation, setSelectedLocation] = useState(null);
@@ -81,6 +83,7 @@ function App() {
     setUser(null);
     setAuthScreen('email');
     setCurrentEmail('');
+    setSelectedPersona(null);
   };
   
   // Magic link authentication handlers
@@ -94,6 +97,7 @@ function App() {
   
   const handleBackToEmail = () => {
     setAuthScreen('email');
+    setSelectedPersona(null);
   };
   
   const handleVerifyMagicLink = () => {
@@ -113,8 +117,10 @@ function App() {
       case 'email':
         return (
           <ErrorBoundary>
-            <EmailScreen 
-              onEmailSubmit={handleEmailSubmit} 
+            <EmailScreen
+              persona={selectedPersona}
+              onPersonaSelect={setSelectedPersona}
+              onEmailSubmit={handleEmailSubmit}
               onKnownUser={handleEmailContinue}
               onNewUser={handleRegisterClick}
             />
@@ -135,8 +141,9 @@ function App() {
       case 'magic-link-verify':
         return (
           <ErrorBoundary>
-            <MagicLinkVerifyScreen 
+            <MagicLinkVerifyScreen
               email={currentEmail}
+              persona={selectedPersona}
               onBack={handleBackToEmail}
               onLogin={handleLogin}
               onRegister={handleRegisterClick}
@@ -147,10 +154,11 @@ function App() {
       case 'register':
         return (
           <ErrorBoundary>
-            <RegisterScreen 
-              onBack={handleBackToEmail} 
+            <RegisterScreen
+              onBack={handleBackToEmail}
               onComplete={handleLogin}
               prefillEmail={currentEmail}
+              persona={selectedPersona}
             />
           </ErrorBoundary>
         );
@@ -159,15 +167,21 @@ function App() {
       case 'login':
         return (
           <ErrorBoundary>
-            <LoginScreen onLogin={handleLogin} onRegister={() => setAuthScreen('register')} />
+            <LoginScreen
+              onLogin={handleLogin}
+              onRegister={() => setAuthScreen('register')}
+              persona={selectedPersona || getRandomDemoPersona()}
+            />
           </ErrorBoundary>
         );
       
       default:
         return (
           <ErrorBoundary>
-            <EmailScreen 
-              onEmailSubmit={handleEmailSubmit} 
+            <EmailScreen
+              persona={selectedPersona}
+              onPersonaSelect={setSelectedPersona}
+              onEmailSubmit={handleEmailSubmit}
               onKnownUser={handleEmailContinue}
               onNewUser={handleRegisterClick}
             />

--- a/src/components/screens/EmailScreen.js
+++ b/src/components/screens/EmailScreen.js
@@ -6,13 +6,24 @@ import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import api from '../../services/api';
 import PageContainer from '../layout/PageContainer';
+import {
+  getDemoEmail,
+  getRandomDemoPersona
+} from '../../utils/demoData';
 
 /**
  * Initial Email Screen for Magic Link authentication
  * @param {Object} props - Component props
  * @returns {JSX.Element} Rendered component
  */
-const EmailScreen = ({ onEmailSubmit, onRegister, onKnownUser, onNewUser }) => {
+const EmailScreen = ({
+  onEmailSubmit,
+  onRegister,
+  onKnownUser,
+  onNewUser,
+  persona,
+  onPersonaSelect
+}) => {
   const [isProcessing, setIsProcessing] = useState(false);
   const [formFilled, setFormFilled] = useState(false);
   
@@ -45,9 +56,11 @@ const EmailScreen = ({ onEmailSubmit, onRegister, onKnownUser, onNewUser }) => {
   
   // Fill form with sample data
   const fillFormWithSampleData = () => {
-    setValues({
-      email: 'john.doe@example.com'
-    });
+    const selected = persona || getRandomDemoPersona();
+    if (!persona && onPersonaSelect) {
+      onPersonaSelect(selected);
+    }
+    setValues(getDemoEmail(selected));
     setFormFilled(true);
   };
   

--- a/src/components/screens/LoginScreen.js
+++ b/src/components/screens/LoginScreen.js
@@ -3,6 +3,11 @@ import { User, Lock, ArrowRight } from 'lucide-react';
 import { FormField, FormButton } from '../ui/form';
 import { useForm } from '../../hooks';
 import api from '../../services/api';
+import {
+  getDemoCredentials,
+  getRandomDemoPersona,
+  getInitials
+} from '../../utils/demoData';
 import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import PageContainer from '../layout/PageContainer';
@@ -12,7 +17,7 @@ import PageContainer from '../layout/PageContainer';
  * @param {Object} props - Component props
  * @returns {JSX.Element} Rendered component
  */
-const LoginScreen = ({ onLogin, onRegister }) => {
+const LoginScreen = ({ onLogin, onRegister, persona }) => {
   const [formFilled, setFormFilled] = useState(false);
   
   // Form validation
@@ -48,11 +53,8 @@ const LoginScreen = ({ onLogin, onRegister }) => {
   
   // Fill form with sample data
   const fillFormWithSampleData = () => {
-    setValues({
-      email: 'john.doe@example.com',
-      password: 'password',
-      rememberMe: false
-    });
+    const selected = persona || getRandomDemoPersona();
+    setValues(getDemoCredentials(selected));
     setFormFilled(true);
   };
   
@@ -65,12 +67,13 @@ const LoginScreen = ({ onLogin, onRegister }) => {
     }
     
     // Second click: Actually log in
-    onLogin({ 
-      id: '1',  // Make sure this matches the userId in the mock locations
-      email: formValues.email, 
-      name: 'John Doe', 
-      role: 'Farm Manager',
-      initials: 'JD'
+    const userPersona = persona || getRandomDemoPersona();
+    onLogin({
+      id: '1',
+      email: formValues.email,
+      name: userPersona.name,
+      role: userPersona.role,
+      initials: getInitials(userPersona.name)
     });
   }
   

--- a/src/components/screens/MagicLinkVerifyScreen.js
+++ b/src/components/screens/MagicLinkVerifyScreen.js
@@ -4,29 +4,31 @@ import { FormButton } from '../ui/form';
 import ErrorBoundary from '../utility/ErrorBoundary';
 import beetGuruWideLogo from '../../BeetGuruWide.png';
 import PageContainer from '../layout/PageContainer';
+import { getInitials } from '../../utils/demoData';
 
 /**
  * Screen shown after magic link verification
  * @param {Object} props - Component props
  * @returns {JSX.Element} Rendered component
  */
-const MagicLinkVerifyScreen = ({ email, onBack, onLogin, onRegister }) => {
+const MagicLinkVerifyScreen = ({ email, persona, onBack, onLogin, onRegister }) => {
   // Handle login demo - immediately login
   const handleLoginDemo = () => {
-    // Simulate existing user login with John Doe data
-    onLogin({ 
+    const selected = persona || { name: 'John Doe', email: email || 'john.doe@example.com', role: 'Farm Manager' };
+    onLogin({
       id: '1',
-      email: email || 'john.doe@example.com', 
-      name: 'John Doe', 
-      role: 'Farm Manager',
-      initials: 'JD'
+      email: selected.email,
+      name: selected.name,
+      role: selected.role,
+      initials: getInitials(selected.name)
     });
   };
   
   // Handle registration demo - immediately go to registration
   const handleRegisterDemo = () => {
     // Redirect to registration form with email pre-filled
-    onRegister(email || 'john.doe@example.com');
+    const selected = persona || { email: email || 'john.doe@example.com', name: 'John Doe' };
+    onRegister(selected.email);
   };
   
   return (

--- a/src/components/screens/RegisterScreen.js
+++ b/src/components/screens/RegisterScreen.js
@@ -5,8 +5,13 @@ import { FormField, FormButton } from '../ui/form';
 import { PrimaryButton } from '../ui/buttons';
 import PageContainer from '../layout/PageContainer';
 import { cn } from '../../utils/cn';
+import {
+  getDemoRegistrationData,
+  getRandomDemoPersona,
+  getInitials
+} from '../../utils/demoData';
 
-const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
+const RegisterScreen = ({ onBack, onComplete, prefillEmail = '', persona }) => {
   const [formData, setFormData] = useState({
     name: '',
     email: prefillEmail || '',
@@ -52,15 +57,8 @@ const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
     cn(formData.userType !== type && userTypeUnselectedClass);
   
   const fillFormWithSampleData = () => {
-    setFormData({
-      name: 'Donald',
-      email: prefillEmail || 'donald@stp.co.nz',
-      password: 'password',
-      confirmPassword: 'password',
-      userType: 'farmer',
-      subscribeToNews: true,
-      agreeToTerms: true
-    });
+    const selected = persona || getRandomDemoPersona();
+    setFormData(getDemoRegistrationData(selected, prefillEmail));
     setFormFilled(true);
   };
   
@@ -74,11 +72,11 @@ const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
     }
     
     // Second click: Complete registration
-    onComplete({ 
+    onComplete({
       email: formData.email,
       name: formData.name,
       role: formData.userType === 'farmer' ? 'Farm Manager' : 'Retail Consultant',
-      initials: formData.name ? formData.name.split(' ').map(n => n && n[0]).join('') : 'D'
+      initials: getInitials(formData.name)
     });
   };
   
@@ -89,11 +87,11 @@ const RegisterScreen = ({ onBack, onComplete, prefillEmail = '' }) => {
       fillFormWithSampleData();
     } else {
       // Handle the second click (complete registration)
-      onComplete({ 
+      onComplete({
         email: formData.email,
         name: formData.name,
         role: formData.userType === 'farmer' ? 'Farm Manager' : 'Retail Consultant',
-        initials: formData.name ? formData.name.split(' ').map(n => n && n[0]).join('') : 'D'
+        initials: getInitials(formData.name)
       });
     }
   };

--- a/src/utils/demoData.js
+++ b/src/utils/demoData.js
@@ -1,0 +1,44 @@
+export const demoPersonas = [
+  { name: 'John Doe', email: 'john.doe@example.com', role: 'Farm Manager' },
+  { name: 'Maria Gonzalez', email: 'maria.gonzalez@example.com', role: 'Agronomist' },
+  { name: 'Chen Wei', email: 'chen.wei@example.com', role: 'Field Technician' },
+  { name: 'Aroha Ngata', email: 'aroha.ngata@example.com', role: 'Farm Hand' },
+  { name: "Liam O'Connor", email: 'liam.oconnor@example.com', role: 'Researcher' },
+  { name: 'Amara Singh', email: 'amara.singh@example.com', role: 'Farm Analyst' },
+  { name: 'Omar Farouk', email: 'omar.farouk@example.com', role: 'Farm Manager' },
+  { name: 'Sofia Rossi', email: 'sofia.rossi@example.com', role: 'Operations Manager' },
+  { name: 'Mateo Alvarez', email: 'mateo.alvarez@example.com', role: 'Agronomist' },
+  { name: 'Keiko Tanaka', email: 'keiko.tanaka@example.com', role: 'Consultant' },
+  { name: 'Hana Ali', email: 'hana.ali@example.com', role: 'Field Specialist' },
+  { name: 'Lucas Martins', email: 'lucas.martins@example.com', role: 'Field Technician' }
+];
+
+export const getRandomDemoPersona = () =>
+  demoPersonas[Math.floor(Math.random() * demoPersonas.length)];
+
+export const getInitials = (name = '') =>
+  name
+    .split(' ')
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase();
+
+export const getDemoEmail = (persona) => ({
+  email: persona.email
+});
+
+export const getDemoCredentials = (persona) => ({
+  email: persona.email,
+  password: 'password',
+  rememberMe: false
+});
+
+export const getDemoRegistrationData = (persona, prefillEmail = '') => ({
+  name: persona.name.split(' ')[0],
+  email: prefillEmail || persona.email,
+  password: 'password',
+  confirmPassword: 'password',
+  userType: 'farmer',
+  subscribeToNews: true,
+  agreeToTerms: true
+});


### PR DESCRIPTION
## Summary
- expand demo data with diverse personas
- select persona on first email continue click
- keep chosen persona through magic link demo
- use helpers in login and registration flows

## Testing
- `CI=true npm test --silent`