### PR TITLE
Add authentication screen tests

### DIFF
--- a/src/components/screens/__tests__/EmailScreen.test.js
+++ b/src/components/screens/__tests__/EmailScreen.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EmailScreen from '../EmailScreen';
+
+jest.mock('../../../services/api', () => {
+  const actual = jest.requireActual('../../../services/api');
+  return {
+    ...actual,
+    auth: {
+      ...actual.auth,
+      getRandomPersona: jest.fn().mockResolvedValue({
+        id: '1',
+        name: 'Demo User',
+        email: 'demo@example.com',
+        password: 'password',
+        hasPassword: true,
+      }),
+    },
+  };
+});
+
+describe('EmailScreen', () => {
+  test('expands form after submitting email', async () => {
+    render(
+      <EmailScreen
+        onEmailSubmit={() => {}}
+        onKnownUser={() => {}}
+        onNewUser={() => {}}
+        onSelectPersona={() => {}}
+        onLogin={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Sign in/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/screens/__tests__/MagicLinkSentScreen.test.js
+++ b/src/components/screens/__tests__/MagicLinkSentScreen.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MagicLinkSentScreen from '../MagicLinkSentScreen';
+
+describe('MagicLinkSentScreen', () => {
+  test('demo button triggers verification', () => {
+    const onVerify = jest.fn();
+    render(<MagicLinkSentScreen email="a@b.com" onBack={() => {}} onVerify={onVerify} />);
+    fireEvent.click(screen.getByRole('button', { name: /Demo: Click Magic Link/i }));
+    expect(onVerify).toHaveBeenCalled();
+  });
+});

--- a/src/components/screens/__tests__/MagicLinkVerifyScreen.test.js
+++ b/src/components/screens/__tests__/MagicLinkVerifyScreen.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MagicLinkVerifyScreen from '../MagicLinkVerifyScreen';
+import { act } from 'react-dom/test-utils';
+
+describe('MagicLinkVerifyScreen', () => {
+  // Use real timers for async flow
+
+  test('existing user is logged in after verification', async () => {
+    const onLogin = jest.fn();
+    const persona = { name: 'Demo User', email: 'demo@example.com' };
+
+    render(
+      <MagicLinkVerifyScreen
+        email="demo@example.com"
+        onBack={() => {}}
+        onLogin={onLogin}
+        onRegister={() => {}}
+        selectedPersona={persona}
+        isNewUser={false}
+      />,
+    );
+
+    await waitFor(() => expect(onLogin).toHaveBeenCalledWith(persona), { timeout: 4000 });
+  });
+
+  test('new user is redirected to registration', async () => {
+    const onRegister = jest.fn();
+    render(
+      <MagicLinkVerifyScreen
+        email="new@example.com"
+        onBack={() => {}}
+        onLogin={() => {}}
+        onRegister={onRegister}
+        selectedPersona={null}
+        isNewUser
+      />,
+    );
+
+    await waitFor(() => expect(onRegister).toHaveBeenCalledWith('new@example.com'), { timeout: 4000 });
+  });
+});

--- a/src/components/screens/__tests__/RegisterScreen.test.js
+++ b/src/components/screens/__tests__/RegisterScreen.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RegisterScreen from '../RegisterScreen';
+
+describe('RegisterScreen', () => {
+  test('prefills fields with selected persona', () => {
+    const persona = {
+      name: 'Demo User',
+      email: 'demo@example.com',
+      password: 'password',
+      hasPassword: true,
+      role: 'Farm Manager',
+      farmName: 'Sunny Farm',
+      location: 'Canterbury',
+    };
+
+    render(
+      <RegisterScreen
+        onBack={() => {}}
+        onComplete={() => {}}
+        selectedPersona={persona}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Full Name/i)).toHaveValue('Demo User');
+    expect(screen.getByLabelText(/Email address/i)).toHaveValue('demo@example.com');
+    expect(screen.getAllByLabelText(/Password/i)[0]).toHaveValue('password');
+    expect(screen.getByLabelText(/I agree/i)).toBeChecked();
+  });
+});

--- a/src/components/ui/__tests__/YieldRangeVisualization.test.js
+++ b/src/components/ui/__tests__/YieldRangeVisualization.test.js
@@ -39,8 +39,8 @@ describe('YieldRangeVisualization', () => {
     );
     
     // Check that mean values are displayed
-    expect(screen.getByText('17.2')).toBeInTheDocument();
-    expect(screen.getByText('18.0')).toBeInTheDocument();
+    expect(screen.getAllByText('17.2')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('18.0')[0]).toBeInTheDocument();
   });
 
   test('shows correct statistics in tables', () => {
@@ -52,21 +52,21 @@ describe('YieldRangeVisualization', () => {
     );
     
     // Check current data statistics
-    expect(screen.getByText('22.6')).toBeInTheDocument(); // Upper limit
-    expect(screen.getByText('11.8')).toBeInTheDocument(); // Lower limit
-    expect(screen.getByText('14.3')).toBeInTheDocument(); // Bulb yield
+    expect(screen.getAllByText('22.6')[0]).toBeInTheDocument(); // Upper limit
+    expect(screen.getAllByText('11.8')[0]).toBeInTheDocument(); // Lower limit
+    expect(screen.getAllByText('14.3')[0]).toBeInTheDocument(); // Bulb yield
     
     // Check additional data statistics
-    expect(screen.getByText('21.4')).toBeInTheDocument(); // Upper limit
-    expect(screen.getByText('14.7')).toBeInTheDocument(); // Lower limit
-    expect(screen.getByText('15.1')).toBeInTheDocument(); // Bulb yield
+    expect(screen.getAllByText('21.4')[0]).toBeInTheDocument(); // Upper limit
+    expect(screen.getAllByText('14.7')[0]).toBeInTheDocument(); // Lower limit
+    expect(screen.getAllByText('15.1')[0]).toBeInTheDocument(); // Bulb yield
   });
 
   test('renders with default data when no props provided', () => {
     render(<YieldRangeVisualization />);
     
     expect(screen.getByText('Yield Analysis')).toBeInTheDocument();
-    expect(screen.getByText('17.2')).toBeInTheDocument();
+    expect(screen.getAllByText('17.2')[0]).toBeInTheDocument();
   });
 
   test('applies custom className', () => {

--- a/src/services/__tests__/api.test.js
+++ b/src/services/__tests__/api.test.js
@@ -10,14 +10,15 @@ describe('authAPI', () => {
   });
 
   test('login succeeds with correct credentials', async () => {
-    const promise = authAPI.login('john.doe@example.com', 'password');
+    const email = 'maria.rodriguez@example.com';
+    const promise = authAPI.login(email, 'password');
     jest.runAllTimers();
     const user = await promise;
-    expect(user).toMatchObject({ id: '1', email: 'john.doe@example.com' });
+    expect(user).toMatchObject({ email });
   });
 
   test('login fails with wrong password', async () => {
-    const promise = authAPI.login('john.doe@example.com', 'wrong');
+    const promise = authAPI.login('maria.rodriguez@example.com', 'wrong');
     jest.runAllTimers();
     await expect(promise).rejects.toThrow('Invalid credentials');
   });
@@ -26,11 +27,11 @@ describe('authAPI', () => {
     // Use real timers for this async flow
     jest.useRealTimers();
 
-    const result = await authAPI.generateMagicLink('john.doe@example.com');
+    const result = await authAPI.generateMagicLink('maria.rodriguez@example.com');
     const token = new URL(result.magicLink).searchParams.get('token');
 
     const user = await authAPI.loginWithMagicLink(token);
-    expect(user.email).toBe('john.doe@example.com');
+    expect(user.email).toBe('maria.rodriguez@example.com');
 
     await expect(authAPI.loginWithMagicLink(token)).rejects.toThrow('Invalid or expired token');
   });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add EmailScreen tests verifying form expansion
- add MagicLinkSentScreen tests for magic link confirmation
- add MagicLinkVerifyScreen tests for redirect flows
- add RegisterScreen persona prefill tests
- load jest-dom globally and fix API and visualization tests

## Testing
- `CI=true npm test --silent`