### PR TITLE
Add tests for new customer features

### DIFF
--- a/src/components/screens/__tests__/CustomerDetailScreen.test.js
+++ b/src/components/screens/__tests__/CustomerDetailScreen.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CustomerDetailScreen from '../CustomerDetailScreen';
+
+jest.mock('../../../hooks', () => ({
+  useApi: jest.fn(),
+  usePagination: jest.fn()
+}));
+
+const { useApi, usePagination } = require('../../../hooks');
+
+const mockPagination = (data) => ({
+  currentData: data,
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: data.length,
+  goToPage: jest.fn(),
+  goToPrevPage: jest.fn(),
+  goToNextPage: jest.fn(),
+  hasNextPage: false,
+  hasPrevPage: false,
+  startIndex: 0,
+  endIndex: data.length
+});
+
+describe('CustomerDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('shows loading skeleton', () => {
+    useApi
+      .mockReturnValueOnce({ data: null, loading: true, error: null, execute: jest.fn() })
+      .mockReturnValue({ data: [], loading: false, error: null, execute: jest.fn() });
+    usePagination.mockReturnValue(mockPagination([]));
+    const { container } = render(
+      <CustomerDetailScreen customerId="1" onBack={() => {}} isMobile={false} />
+    );
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+  });
+
+  test('renders customer info and create assessment action', () => {
+    const customer = { id: '1', name: 'Fred Forger', email: 'fred@b.com', status: 'active' };
+    const locations = [{ id: 'l1', name: 'Paddock 1', area: 1 }];
+    useApi
+      .mockReturnValueOnce({ data: customer, loading: false, error: null, execute: jest.fn() })
+      .mockReturnValueOnce({ data: locations, loading: false, error: null, execute: jest.fn() })
+      .mockReturnValueOnce({ data: [], loading: false, error: null, execute: jest.fn() })
+      .mockReturnValueOnce({ data: [], loading: false, error: null, execute: jest.fn() });
+    usePagination.mockReturnValue(mockPagination([]));
+    const onCreate = jest.fn();
+    render(
+      <CustomerDetailScreen
+        customerId="1"
+        onBack={() => {}}
+        onCreateAssessment={onCreate}
+        onViewReport={() => {}}
+        isMobile={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Create New Assessment/i }));
+    expect(onCreate).toHaveBeenCalledWith(customer);
+    expect(screen.getByText('No reports found')).toBeInTheDocument();
+  });
+});

--- a/src/components/screens/__tests__/CustomersScreen.test.js
+++ b/src/components/screens/__tests__/CustomersScreen.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CustomersScreen from '../CustomersScreen';
+
+jest.mock('../../../hooks', () => ({
+  useApi: jest.fn(),
+  usePagination: jest.fn()
+}));
+
+const { useApi, usePagination } = require('../../../hooks');
+
+const mockPagination = (data) => ({
+  currentData: data,
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: data.length,
+  goToPage: jest.fn(),
+  goToPrevPage: jest.fn(),
+  goToNextPage: jest.fn(),
+  hasNextPage: false,
+  hasPrevPage: false,
+  startIndex: 0,
+  endIndex: data.length
+});
+
+describe('CustomersScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('shows loading skeleton', () => {
+    useApi.mockReturnValue({ data: null, loading: true, error: null, execute: jest.fn() });
+    usePagination.mockReturnValue(mockPagination([]));
+    const { container } = render(<CustomersScreen user={{ id: '2' }} />);
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+  });
+
+  test('renders customers and handles row click', () => {
+    const customers = [{ id: '1', name: 'Fred Forger', email: 'fred@b.com', status: 'active', location: 'NZ' }];
+    useApi.mockReturnValue({ data: customers, loading: false, error: null, execute: jest.fn() });
+    usePagination.mockReturnValue(mockPagination(customers));
+    const onViewCustomer = jest.fn();
+    render(<CustomersScreen user={{ id: '2' }} onViewCustomer={onViewCustomer} />);
+    fireEvent.click(screen.getByText('Fred Forger'));
+    expect(onViewCustomer).toHaveBeenCalledWith('1');
+  });
+
+  test('shows empty state when no customers', () => {
+    useApi.mockReturnValue({ data: [], loading: false, error: null, execute: jest.fn() });
+    usePagination.mockReturnValue(mockPagination([]));
+    render(<CustomersScreen user={{ id: '2' }} />);
+    expect(screen.getByText('No customers found')).toBeInTheDocument();
+  });
+});

--- a/src/services/__tests__/customersApi.test.js
+++ b/src/services/__tests__/customersApi.test.js
@@ -1,0 +1,38 @@
+import api from '../api';
+
+describe('customersAPI', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('getByRetailerId returns customers with paddock info', async () => {
+    const promise = api.customers.getByRetailerId('2');
+    jest.runAllTimers();
+    const customers = await promise;
+    expect(customers.length).toBeGreaterThan(0);
+    expect(customers[0]).toHaveProperty('paddockCount');
+  });
+
+  test('getById returns customer details', async () => {
+    const promise = api.customers.getById('1');
+    jest.runAllTimers();
+    const customer = await promise;
+    expect(customer).toMatchObject({ id: '1', name: expect.any(String) });
+    expect(customer).toHaveProperty('relationshipStart');
+  });
+
+  test('createRelationship adds a new customer', async () => {
+    const promise = api.customers.createRelationship('2', {
+      name: 'New Farmer',
+      email: 'new@farm.com'
+    });
+    jest.runAllTimers();
+    const result = await promise;
+    expect(result.name).toBe('New Farmer');
+    expect(result.status).toBe('active');
+  });
+});


### PR DESCRIPTION
## Summary
- test customers API for retailer workflow
- add CustomersScreen tests
- add CustomerDetailScreen tests

## Testing
- `npm test --silent -- -w=0`


------
https://chatgpt.com/codex/tasks/task_b_6840a5a43488832983bc301c70a7437e